### PR TITLE
課題2後半（旧課題4）Exception 対応

### DIFF
--- a/src/main/kotlin/com/example/cypherhelloworld/ApiErrorController.kt
+++ b/src/main/kotlin/com/example/cypherhelloworld/ApiErrorController.kt
@@ -1,0 +1,15 @@
+package com.example.cypherhelloworld
+
+import org.springframework.boot.web.servlet.error.ErrorController
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ApiErrorController : ErrorController {
+
+    @GetMapping("/error")
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    fun showError() : ApiErrorResponse = ApiErrorResponse("something wrong ;-(")
+}

--- a/src/main/kotlin/com/example/cypherhelloworld/ApiException.kt
+++ b/src/main/kotlin/com/example/cypherhelloworld/ApiException.kt
@@ -1,0 +1,3 @@
+package com.example.cypherhelloworld
+
+class ApiException(message: String) : Exception(message)

--- a/src/main/kotlin/com/example/cypherhelloworld/HelloWorldController.kt
+++ b/src/main/kotlin/com/example/cypherhelloworld/HelloWorldController.kt
@@ -12,4 +12,10 @@ class HelloWorldController {
 
     @GetMapping("/hello/name")
     fun name(@RequestParam name: String): HelloNameResponse = HelloNameResponse("Hello, $name")
+
+    // 例外テスト用
+    @GetMapping("/throw-exception")
+    fun throwException() {
+        throw ApiException("テスト用のエラーです")
+    }
 }


### PR DESCRIPTION
### 課題
Applicationで例外が発生した際、HTTP Status 500でJsonを返却してください。
例:  {“reason”:“something wrong ;-(“}

### 確認方法
例外をthrowするエンドポイントを実装した。（/throw-exception）
これにアクセスすると、上記のjsonが返される。

存在しないエンドポイントの場合は、変わらず“no handler found”が返される。

### 解法
/error エンドポイントを上書きする
/error エンドポイントは、デフォルトではwhite label error pageのレスポンスを返している

公式（参考の一つ目）より、
> By default, Spring Boot provides an /error mapping that handles all errors in a sensible way, and it is registered as a “global” error page in the servlet container. 

### 参考
- https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#features.developing-web-applications.spring-mvc.error-handling
- https://qiita.com/leonis_sk/items/c954face2c5c1cbf3802