### PR TITLE
No.4 Spring Profilesごとに定数を定義する	

### DIFF
--- a/src/main/kotlin/com/example/cypherhelloworld/ApiMessageProperties.kt
+++ b/src/main/kotlin/com/example/cypherhelloworld/ApiMessageProperties.kt
@@ -1,0 +1,10 @@
+package com.example.cypherhelloworld
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "message")
+data class ApiMessageProperties(
+    val call: String
+)

--- a/src/main/kotlin/com/example/cypherhelloworld/HelloWorldController.kt
+++ b/src/main/kotlin/com/example/cypherhelloworld/HelloWorldController.kt
@@ -1,5 +1,6 @@
 package com.example.cypherhelloworld
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -7,16 +8,22 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import javax.validation.constraints.Size
 
+@EnableConfigurationProperties(ApiMessageProperties::class)
 @Validated
 @RestController
 @RequestMapping("/hello")
-class HelloWorldController {
+class HelloWorldController(
+    val apiMessageProperties: ApiMessageProperties
+) {
 
     @GetMapping
     fun hello(): String = "Hello World"
 
     @GetMapping("/name")
-    fun name(@RequestParam @Size(min = 3, max = 10) name: String): HelloNameResponse = HelloNameResponse("Hello, $name")
+    fun name(@RequestParam @Size(min = 3, max = 10) name: String): HelloNameResponse {
+        val call = apiMessageProperties.call
+        return HelloNameResponse("Hello, $call, $name")
+    }
 
     // 例外テスト用
     @GetMapping("/throw-exception")

--- a/src/main/resources/application-message-dev.yml
+++ b/src/main/resources/application-message-dev.yml
@@ -1,0 +1,3 @@
+## 環境で変わるメッセージ
+message:
+  call: "my best friend"

--- a/src/main/resources/application-message.yml
+++ b/src/main/resources/application-message.yml
@@ -1,0 +1,3 @@
+## 環境で変わるメッセージ
+message:
+  call: "my friend"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,11 @@ spring:
   web:
     resources:
       add-mappings: false
+  config:
+    import: classpath:application-message.yml
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+    import: classpath:application-message-dev.yml


### PR DESCRIPTION
### 課題
- APIのResponseを  {"message":"Hello $text, $name"} に修正してください
- textの値はapplication.ymlに定義してApplication内で利用してください
- spring profilesがdevのときはtextの値を変えてください
  - spring profiles dev以外の場合の出力: {"message":"Hello my best friend, foo"}
  - spring profiles がdevの場合の出力: {"message":"Hello my friend, foo"} 

### 解法
- プロファイルごとのプロパティファイルの作成、環境別の読み込み
- プログラム側で、プロパティファイルの中身を受けるdataクラスを作成
- コントローラーで上記dataクラスを使ってレスポンスを作成するよう修正

### 確認方法
Java VM Optionか、プログラム起動時の引数で、「spring.profiles.activate=dev」というようにを指定する。devとそれ以外でレスポンスが変わる
```
// VM optionの場合
-Dspring.profiles.activate=dev

// 起動時引数の場合
--spring.profiles.activate=dev
```

